### PR TITLE
fix: Chrome doesn't implement web-share

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
             [[[Web-Share]]]
           </td>
           <td class="imp-chromium">
-            YES
+            NO
           </td>
           <td class="imp-gecko">
             YES


### PR DESCRIPTION
Not implemented yet in Chrome (https://github.com/w3c/web-share/issues/169). 

It's implemented in the engines tho.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 25, 2022, 4:44 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fpermissions-registry%2F9bf913b2e9ba59627d93a7f7c9865452ccf32c4a%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/oCQ7pE
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/permissions-registry%2313.)._
</details>
