### PR TITLE
Add "accelerometer" to registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,31 @@
           <th>
             <a href="https://webkit.org/">WebKit</a>
           </th>
-        </tr><!--
+        </tr>
+        <tr data-cite="accelerometer">
+          <td class="string-token">
+            "[=accelerometer=]"
+          </td>
+          <td class="is-policy-controlled">
+            YES
+          </td>
+          <td class="is-powerful-feature">
+            YES
+          </td>
+          <td class="spec">
+            [[[accelerometer]]]
+          </td>
+          <td class="imp-chromium">
+            YES
+          </td>
+          <td class="imp-gecko">
+            NO
+          </td>
+          <td class="imp-webkit">
+            NO
+          </td>
+        </tr>
+        <!--
           You can add a row to this table by copy/pasting the following.
         -->
         <!--tr data-cite="spec-shortname">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions-registry/pull/16.html" title="Last updated on Oct 23, 2022, 2:07 PM UTC (d237536)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions-registry/16/4e0bc0d...d237536.html" title="Last updated on Oct 23, 2022, 2:07 PM UTC (d237536)">Diff</a>