### PR TITLE
Add local-fonts to table of provisional permissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,7 +396,7 @@
             NO
           </td>
         </tr>
-        <tr data-cite="local-font-access">
+         <tr data-cite="local-font-access">
           <td class="string-token">
             "[=local-fonts=]"
           </td>

--- a/index.html
+++ b/index.html
@@ -396,6 +396,29 @@
             NO
           </td>
         </tr>
+        <tr data-cite="local-fonts">
+          <td class="string-token">
+            "[=local-fonts=]"
+          </td>
+          <td class="is-policy-controlled">
+            YES
+          </td>
+          <td class="is-powerful-feature">
+            YES
+          </td>
+          <td class="spec">
+            [[[local-font-access]]]
+          </td>
+          <td class="imp-chromium">
+            YES
+          </td>
+          <td class="imp-gecko">
+            NO
+          </td>
+          <td class="imp-webkit">
+            NO
+          </td>
+        </tr>
         <!--
           You can add a row to this table by copy/pasting the following.
         -->

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
           </td>
         </tr>
         <tr data-cite="local-fonts">
-           <td class="string-token">
+          <td class="string-token">
             "[=local-fonts=]"
           </td>
           <td class="is-policy-controlled">

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
           </td>
         </tr>
         <tr data-cite="local-fonts">
-          <td class="string-token">
+           <td class="string-token">
             "[=local-fonts=]"
           </td>
           <td class="is-policy-controlled">

--- a/index.html
+++ b/index.html
@@ -396,7 +396,7 @@
             NO
           </td>
         </tr>
-         <tr data-cite="local-font-access">
+        <tr data-cite="local-font-access">
           <td class="string-token">
             "[=local-fonts=]"
           </td>

--- a/index.html
+++ b/index.html
@@ -396,7 +396,7 @@
             NO
           </td>
         </tr>
-        <tr data-cite="local-fonts">
+        <tr data-cite="local-font-access">
           <td class="string-token">
             "[=local-fonts=]"
           </td>


### PR DESCRIPTION
Per https://wicg.github.io/local-font-access/#permissions

@miketaylr - can you take a look?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/permissions-registry/pull/20.html" title="Last updated on Dec 7, 2022, 9:56 PM UTC (f2c1ab3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions-registry/20/d7e4318...inexorabletash:f2c1ab3.html" title="Last updated on Dec 7, 2022, 9:56 PM UTC (f2c1ab3)">Diff</a>