### PR TITLE
Update index.html window-placement to window-management

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,14 +92,14 @@
             <li>The string that identifies the policy controlled feature (e.g., `"super-awesome"`).
             Make sure the string is linkable by wrapping it a [^dfn^] element.
             </li>
-            <li>The [=default allowlist=] value (e.g. `'self'`).
+            <li>The [=policy-controlled feature/default allowlist=] value (e.g. `'self'`).
               <aside class="example" title="Specifying a Permissions Policy">
                 <p>
                   An typical example that would meet this criteria:
                 </p>
                 <blockquote>
                   The Super Awesome API defines a [=policy-controlled feature=] identified by the
-                  string "super-awesome". Its [=default allowlist=] is `'self'`.
+                  string "super-awesome". Its [=policy-controlled feature/default allowlist=] is `'self'`.
                 </blockquote>
               </aside>
             </li>

--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@
             NO
           </td>
         </tr>
-        <tr data-cite="window-placement">
+        <tr data-cite="window-management">
           <td class="string-token">
             "[=window-management=]"
           </td>
@@ -384,7 +384,7 @@
             YES
           </td>
           <td class="spec">
-            [[[window-placement]]]
+            [[[window-management]]]
           </td>
           <td class="imp-chromium">
             YES


### PR DESCRIPTION
Intended to update respec references to legacy "Multi-Screen Window Placement" and "https://www.w3.org/TR/window-placement/" to the modern "Window Management" and "https://www.w3.org/TR/window-management/"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/michaelwasserman/permissions-registry/pull/24.html" title="Last updated on Nov 10, 2023, 11:16 PM UTC (776df43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions-registry/24/51fb32e...michaelwasserman:776df43.html" title="Last updated on Nov 10, 2023, 11:16 PM UTC (776df43)">Diff</a>